### PR TITLE
substitute deprecated OpenAI model

### DIFF
--- a/1_Main_Basics_of_LangChain.ipynb
+++ b/1_Main_Basics_of_LangChain.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "import os\n",
     "\n",
-    "llm = OpenAI(model_name=\"text-ada-001\")\n",
+    "llm = OpenAI(model_name=\"babbage-002\")\n",
     "print(llm(\"Explain me briefly whta's KDnuggets!\"))"
    ]
   },


### PR DESCRIPTION
Thanks for the great LangChain tutorial, great way to get started!

I noticed that the `text-ada-001` model is deprecated; using `babbage-002` instead works.